### PR TITLE
FIR-347 | Update association syntax to support Ruby 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)

--- a/app/views/associations/_direct_long_belongs_to.html.erb
+++ b/app/views/associations/_direct_long_belongs_to.html.erb
@@ -29,10 +29,10 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  belongs_to(:#{@association.name}, {
+  belongs_to(:#{@association.name},
     :class_name => "#{@association.parent_model.class_name}",
     :foreign_key => "#{@association.foreign_key}"
-  })
+  )
   
   # ...
 end
@@ -49,11 +49,11 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  belongs_to(:#{@association.name}, {
+  belongs_to(:#{@association.name},
     :class_name => "#{@association.parent_model.class_name}",
     :foreign_key => "#{@association.foreign_key}",
     :required => true
-  })
+  )
   
   # ...
 end
@@ -75,9 +75,9 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  belongs_to(:#{@association.name}, {
+  belongs_to(:#{@association.name},
     :class_name => "#{@association.parent_model.class_name}"
-  })
+  )
   
   # ...
 end
@@ -104,9 +104,9 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  belongs_to(:#{@association.name}, {
+  belongs_to(:#{@association.name},
     :foreign_key => "#{@association.foreign_key}"
-  })
+  )
   
   # ...
 end

--- a/app/views/associations/_direct_long_has_many.html.erb
+++ b/app/views/associations/_direct_long_has_many.html.erb
@@ -27,10 +27,10 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_many(:#{@association.name}, {
+  has_many(:#{@association.name},
     :class_name => "#{@association.foreign_key_location_model.class_name}",
     :foreign_key => "#{@association.foreign_key}"
-  })
+  )
   
   # ...
 end
@@ -47,11 +47,11 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_many(:#{@association.name}, {
+  has_many(:#{@association.name},
     :class_name => "#{@association.foreign_key_location_model.class_name}",
     :foreign_key => "#{@association.foreign_key}",
     :dependent => :destroy
-  })
+  )
   
   # ...
 end
@@ -73,9 +73,9 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_many(:#{@association.name}, {
+  has_many(:#{@association.name},
     :foreign_key => "#{@association.foreign_key}"
-  })
+  )
   
   # ...
 end
@@ -102,9 +102,9 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_many(:#{@association.name}, {
+  has_many(:#{@association.name},
     :class_name => "#{@association.foreign_key_location_model.class_name}"
-  })
+  )
   
   # ...
 end

--- a/app/views/associations/_indirect_long_many_many.html.erb
+++ b/app/views/associations/_indirect_long_many_many.html.erb
@@ -53,10 +53,10 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_many(:#{@association.name}, {
+  has_many(:#{@association.name},
     :through => :#{@association.through_association.name},
     :source => :#{@association.source_association.name}
-  })
+  )
   
   # ...
 end
@@ -91,9 +91,9 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_many(:#{@association.name}, {
+  has_many(:#{@association.name},
     :through => :#{@association.through_association.name}
-  })
+  )
   
   # ...
 end

--- a/app/views/associations/_indirect_long_many_one.html.erb
+++ b/app/views/associations/_indirect_long_many_one.html.erb
@@ -51,10 +51,10 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_many(:#{@association.name}, {
+  has_many(:#{@association.name},
     :through => :#{@association.through_association.name},
     :source => :#{@association.source_association.name}
-  })
+  )
   
   # ...
 end
@@ -89,9 +89,9 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_many(:#{@association.name}, {
+  has_many(:#{@association.name},
     :through => :#{@association.through_association.name}
-  })
+  )
   
   # ...
 end

--- a/app/views/associations/_indirect_long_one_many.html.erb
+++ b/app/views/associations/_indirect_long_one_many.html.erb
@@ -53,10 +53,10 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_many(:#{@association.name}, {
+  has_many(:#{@association.name},
     :through => :#{@association.through_association.name},
     :source => :#{@association.source_association.name}
-  })
+  )
   
   # ...
 end


### PR DESCRIPTION
Resolves [FIR-347](https://linear.app/firstdraft/issue/FIR-347/change-keyword-arguments-in-ideas-and-association-accessors)

## Problem

Ruby 3+ apps have breaking changes to how keyword arguments work. In Ideas, this specifically affects the "optional curly braces" setting in the Copilot. 

In Ruby 3+, the only valid syntaxes are:

```rb
has_many(:likes, **{ :class_name => "Like", :foreign_key => "user_id", :dependent => :destroy })
```

or

```rb
has_many(:likes, :class_name => "Like", :foreign_key => "user_id", :dependent => :destroy)
```

## Solution

The agreed-upon solution is to remove curly braces entirely from the association accessor methods.

This PR removes curly braces from all association method arguments.
