### PR TITLE
Use keyword argument syntax

### DIFF
--- a/app/views/associations/_direct_long_belongs_to.html.erb
+++ b/app/views/associations/_direct_long_belongs_to.html.erb
@@ -30,8 +30,8 @@ class #{@association.origin_model.class_name}
   # ...
 
   belongs_to(:#{@association.name},
-    :class_name => "#{@association.parent_model.class_name}",
-    :foreign_key => "#{@association.foreign_key}"
+    class_name: "#{@association.parent_model.class_name}",
+    foreign_key: "#{@association.foreign_key}"
   )
   
   # ...
@@ -43,16 +43,16 @@ CODE
 
 <hr>
 
-<p class="lead">One of many advantages of using <a href="https://guides.rubyonrails.org/association_basics.html" target="_blank">ActiveRecord's built-in Associations</a> instead of hand-writing accessor methods is that we can add additional options to the configuration hash. For example, the <code>:required => :true</code> option is very often useful to add to the <code>belongs_to</code> side of a direct association:</p>
+<p class="lead">One of many advantages of using <a href="https://guides.rubyonrails.org/association_basics.html" target="_blank">ActiveRecord's built-in Associations</a> instead of hand-writing accessor methods is that we can add additional options to the configuration hash. For example, the <code>required: true</code> option is very often useful to add to the <code>belongs_to</code> side of a direct association:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
 class #{@association.origin_model.class_name}
   # ...
 
   belongs_to(:#{@association.name},
-    :class_name => "#{@association.parent_model.class_name}",
-    :foreign_key => "#{@association.foreign_key}",
-    :required => true
+    class_name: "#{@association.parent_model.class_name}",
+    foreign_key: "#{@association.foreign_key}",
+    required: true
   )
   
   # ...
@@ -76,7 +76,7 @@ class #{@association.origin_model.class_name}
   # ...
 
   belongs_to(:#{@association.name},
-    :class_name => "#{@association.parent_model.class_name}"
+    class_name: "#{@association.parent_model.class_name}"
   )
   
   # ...
@@ -105,7 +105,7 @@ class #{@association.origin_model.class_name}
   # ...
 
   belongs_to(:#{@association.name},
-    :foreign_key => "#{@association.foreign_key}"
+    foreign_key: "#{@association.foreign_key}"
   )
   
   # ...

--- a/app/views/associations/_direct_long_has_many.html.erb
+++ b/app/views/associations/_direct_long_has_many.html.erb
@@ -28,8 +28,8 @@ class #{@association.origin_model.class_name}
   # ...
 
   has_many(:#{@association.name},
-    :class_name => "#{@association.foreign_key_location_model.class_name}",
-    :foreign_key => "#{@association.foreign_key}"
+    class_name: "#{@association.foreign_key_location_model.class_name}",
+    foreign_key: "#{@association.foreign_key}"
   )
   
   # ...
@@ -41,16 +41,16 @@ CODE
 
 <hr>
 
-<p class="lead">One of many advantages of using <a href="https://guides.rubyonrails.org/association_basics.html" target="_blank">ActiveRecord's built-in Associations</a> instead of hand-writing accessor methods is that we can add additional options to the configuration hash. For example, the <code>:dependent => :destroy</code> option is very often useful to add to the <code>has_many</code> side of a direct association:</p>
+<p class="lead">One of many advantages of using <a href="https://guides.rubyonrails.org/association_basics.html" target="_blank">ActiveRecord's built-in Associations</a> instead of hand-writing accessor methods is that we can add additional options to the configuration hash. For example, the <code>dependent: :destroy</code> option is very often useful to add to the <code>has_many</code> side of a direct association:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
 class #{@association.origin_model.class_name}
   # ...
 
   has_many(:#{@association.name},
-    :class_name => "#{@association.foreign_key_location_model.class_name}",
-    :foreign_key => "#{@association.foreign_key}",
-    :dependent => :destroy
+    class_name: "#{@association.foreign_key_location_model.class_name}",
+    foreign_key: "#{@association.foreign_key}",
+    dependent: :destroy
   )
   
   # ...
@@ -74,7 +74,7 @@ class #{@association.origin_model.class_name}
   # ...
 
   has_many(:#{@association.name},
-    :foreign_key => "#{@association.foreign_key}"
+    foreign_key: "#{@association.foreign_key}"
   )
   
   # ...
@@ -103,7 +103,7 @@ class #{@association.origin_model.class_name}
   # ...
 
   has_many(:#{@association.name},
-    :class_name => "#{@association.foreign_key_location_model.class_name}"
+    class_name: "#{@association.foreign_key_location_model.class_name}"
   )
   
   # ...

--- a/app/views/associations/_indirect_long_many_many.html.erb
+++ b/app/views/associations/_indirect_long_many_many.html.erb
@@ -54,8 +54,8 @@ class #{@association.origin_model.class_name}
   # ...
 
   has_many(:#{@association.name},
-    :through => :#{@association.through_association.name},
-    :source => :#{@association.source_association.name}
+    through: :#{@association.through_association.name},
+    source: :#{@association.source_association.name}
   )
   
   # ...
@@ -92,7 +92,7 @@ class #{@association.origin_model.class_name}
   # ...
 
   has_many(:#{@association.name},
-    :through => :#{@association.through_association.name}
+    through: :#{@association.through_association.name}
   )
   
   # ...

--- a/app/views/associations/_indirect_long_many_one.html.erb
+++ b/app/views/associations/_indirect_long_many_one.html.erb
@@ -52,8 +52,8 @@ class #{@association.origin_model.class_name}
   # ...
 
   has_many(:#{@association.name},
-    :through => :#{@association.through_association.name},
-    :source => :#{@association.source_association.name}
+    through: :#{@association.through_association.name},
+    source: :#{@association.source_association.name}
   )
   
   # ...
@@ -90,7 +90,7 @@ class #{@association.origin_model.class_name}
   # ...
 
   has_many(:#{@association.name},
-    :through => :#{@association.through_association.name}
+    through: :#{@association.through_association.name}
   )
   
   # ...

--- a/app/views/associations/_indirect_long_one_many.html.erb
+++ b/app/views/associations/_indirect_long_one_many.html.erb
@@ -54,8 +54,8 @@ class #{@association.origin_model.class_name}
   # ...
 
   has_many(:#{@association.name},
-    :through => :#{@association.through_association.name},
-    :source => :#{@association.source_association.name}
+    through: :#{@association.through_association.name},
+    source: :#{@association.source_association.name}
   )
   
   # ...
@@ -91,9 +91,9 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_many(:#{@association.name}, {
-    :through => :#{@association.through_association.name}
-  })
+  has_many(:#{@association.name},
+    through: :#{@association.through_association.name}
+  )
   
   # ...
 end

--- a/app/views/associations/_indirect_long_one_one.html.erb
+++ b/app/views/associations/_indirect_long_one_one.html.erb
@@ -43,10 +43,10 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_one(:#{@association.name}, {
-    :through => :#{@association.through_association.name},
-    :source => :#{@association.source_association.name}
-  })
+  has_one(:#{@association.name},
+    through: :#{@association.through_association.name},
+    source: :#{@association.source_association.name}
+  )
   
   # ...
 end
@@ -81,9 +81,9 @@ CODE
 class #{@association.origin_model.class_name}
   # ...
 
-  has_one(:#{@association.name}, {
-    :through => :#{@association.through_association.name}
-  })
+  has_one(:#{@association.name},
+    through: :#{@association.through_association.name}
+  )
   
   # ...
 end


### PR DESCRIPTION
Related to https://github.com/firstdraft/ideas/issues/2040 by using keyword arguments. 

I chose not to drop the parentheses here because of the multi-line breaks in the associations. The parentheses make the accessor arguments more clear. We could move everything to one line, but that will lead to scrolled output and I think it looks nice as is with line breaks.