### PR TITLE
Ensure rendered models inherit from base class

### DIFF
--- a/app/views/associations/_direct_long_belongs_to.html.erb
+++ b/app/views/associations/_direct_long_belongs_to.html.erb
@@ -5,7 +5,7 @@
 <p class="lead">Okay! With that info, we can help you write a method that makes it easy to query this relationship:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   def #{@association.name}
@@ -26,7 +26,7 @@ CODE
 <p class="lead">But, here's a shorthand notation for telling Rails the same things you said when you filled out the wizard:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   belongs_to(:#{@association.name},
@@ -46,7 +46,7 @@ CODE
 <p class="lead">One of many advantages of using <a href="https://guides.rubyonrails.org/association_basics.html" target="_blank">ActiveRecord's built-in Associations</a> instead of hand-writing accessor methods is that we can add additional options to the configuration hash. For example, the <code>required: true</code> option is very often useful to add to the <code>belongs_to</code> side of a direct association:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   belongs_to(:#{@association.name},
@@ -72,7 +72,7 @@ CODE
     <p class="lead">Since the name of the foreign key column, <code><%=@association.foreign_key %></code>, matches the name of the method you're defining, <code><%= @association.name %></code>, you can leave the <code>:foreign_key</code> option out of the hash; and Rails will infer the foreign key column you want to use:</p>
     
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   belongs_to(:#{@association.name},
@@ -90,7 +90,7 @@ CODE
 
     <% if @association.can_eliminate_foreign_key? %>
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   belongs_to(:#{@association.name})
@@ -101,7 +101,7 @@ CODE
 )).html_safe %>
     <% else %>
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   belongs_to(:#{@association.name},

--- a/app/views/associations/_direct_long_has_many.html.erb
+++ b/app/views/associations/_direct_long_has_many.html.erb
@@ -5,7 +5,7 @@
 <p class="lead">Okay! With that info, we can help you write a method that makes it easy to query this relationship:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   def #{@association.name}
@@ -24,7 +24,7 @@ CODE
 <p class="lead">But, here's a shorthand notation for telling Rails the same things you said when you filled out the wizard:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name},
@@ -44,7 +44,7 @@ CODE
 <p class="lead">One of many advantages of using <a href="https://guides.rubyonrails.org/association_basics.html" target="_blank">ActiveRecord's built-in Associations</a> instead of hand-writing accessor methods is that we can add additional options to the configuration hash. For example, the <code>dependent: :destroy</code> option is very often useful to add to the <code>has_many</code> side of a direct association:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name},
@@ -70,7 +70,7 @@ CODE
     <p class="lead">Since the name of the new method you want to define, <code><%= @association.name %></code>, matches the name of the associated model, <code><%= @association.foreign_key_location_model.class_name %></code>, you can leave the <code>:class_name</code> option out of the hash; and Rails will infer the class you want it to use:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name},
@@ -88,7 +88,7 @@ CODE
 
     <% if @association.can_eliminate_class_name? %>
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name})
@@ -99,7 +99,7 @@ CODE
 )).html_safe %>
     <% else %>
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name},

--- a/app/views/associations/_indirect_long_many_many.html.erb
+++ b/app/views/associations/_indirect_long_many_many.html.erb
@@ -9,7 +9,7 @@
 <p class="lead">Okay! With that info, we can help you write a method that makes it easy to query this relationship:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   def #{@association.name}
@@ -50,7 +50,7 @@ CODE
 <p class="lead">But, here's a shorthand notation for telling Rails the same things you said when you filled out the wizard:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name},
@@ -88,7 +88,7 @@ CODE
 <p class="lead">Since the name of the new method you want to define, <code><%= @association.name %></code>, matches the name of the source association, <code><%= @association.source_association.name %></code>, you can leave it out of the shorthand; and Rails will assume that's the method you want it to call on the joining <code><%= @association.join_model.class_name %></code>:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name},

--- a/app/views/associations/_indirect_long_many_one.html.erb
+++ b/app/views/associations/_indirect_long_many_one.html.erb
@@ -9,7 +9,7 @@
 <p class="lead">Okay! With that info, we can help you write a method that makes it easy to query this relationship:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   def #{@association.name}
@@ -48,7 +48,7 @@ CODE
 <p class="lead">But, here's a shorthand notation for telling Rails the same things you said when you filled out the wizard:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name},
@@ -86,7 +86,7 @@ CODE
 <p class="lead">Since the name of the new method you want to define, <code><%= @association.name %></code>, matches the name of the source association, <code><%= @association.source_association.name %></code>, you can leave it out of the shorthand; and Rails will assume that's the method you want it to call on the joining <code><%= @association.join_model.class_name %></code>:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name},

--- a/app/views/associations/_indirect_long_one_many.html.erb
+++ b/app/views/associations/_indirect_long_one_many.html.erb
@@ -9,7 +9,7 @@
 <p class="lead">Okay! With that info, we can help you write a method that makes it easy to query this relationship:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   def #{@association.name}
@@ -50,7 +50,7 @@ CODE
 <p class="lead">But, here's a shorthand notation for telling Rails the same things you said when you filled out the wizard:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name},
@@ -88,7 +88,7 @@ CODE
 <p class="lead">Since the name of the new method you want to define, <code><%= @association.name %></code>, matches the name of the source association, <code><%= @association.source_association.name %></code>, you can leave it out of the shorthand; and Rails will assume that's the method you want it to call on the joining <code><%= @association.join_model.class_name %></code>:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_many(:#{@association.name},

--- a/app/views/associations/_indirect_long_one_one.html.erb
+++ b/app/views/associations/_indirect_long_one_one.html.erb
@@ -9,7 +9,7 @@
 <p class="lead">Okay! With that info, we can help you write a method that makes it easy to query this relationship:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   def #{@association.name}
@@ -40,7 +40,7 @@ CODE
 <p class="lead">But, here's a shorthand notation for telling Rails the same things you said when you filled out the wizard:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_one(:#{@association.name},
@@ -78,7 +78,7 @@ CODE
 <p class="lead">Since the name of the new method you want to define, <code><%= @association.name %></code>, matches the name of the source association, <code><%= @association.source_association.name %></code>, you can leave it out of the shorthand; and Rails will assume that's the method you want it to call on the joining <code><%= @association.join_model.class_name %></code>:</p>
 
 <%= @formatter.format(@lexer.lex(<<-CODE
-class #{@association.origin_model.class_name}
+class #{@association.origin_model.class_name} < ApplicationRecord
   # ...
 
   has_one(:#{@association.name},


### PR DESCRIPTION
Resolves #9 

## Problem

Currently, rendered models don't inherit from `ActiveRecord::Base` or `ApplicationRecord` so the code that is generated by the wizard is partially incorrect.

## Solution

This commit adds inheritance to all rendered models, so the generated code is correct and more accurate to the curriculum.


![image](https://github.com/user-attachments/assets/333f919d-682e-4230-a637-9090c4809ab2)
